### PR TITLE
Make PrivCount Tor Events Consistent

### DIFF
--- a/changes/bug21406
+++ b/changes/bug21406
@@ -1,0 +1,5 @@
+  o Minor bugfixes (code correctness):
+    - Accurately identify client connections using their lack of peer
+      authentication. This means that we bail out earlier if asked to extend
+      to a client. Follow-up to 21407.
+      Fixes bug 21406; bugfix on 0.2.4.23.

--- a/src/or/channel.h
+++ b/src/or/channel.h
@@ -198,8 +198,8 @@ struct channel_s {
   unsigned int is_bad_for_new_circs:1;
 
   /** True iff we have decided that the other end of this connection
-   * is a client.  Channels with this flag set should never be used
-   * to satisfy an EXTEND request.  */
+   * is a client or bridge relay.  Connections with this flag set should never
+   * be used to satisfy an EXTEND request. */
   unsigned int is_client:1;
 
   /** Set if the channel was initiated remotely (came from a listener) */

--- a/src/or/channeltls.c
+++ b/src/or/channeltls.c
@@ -1640,6 +1640,10 @@ channel_tls_process_netinfo_cell(cell_t *cell, channel_tls_t *chan)
         tor_assert(tor_digest_is_zero(
                   (const char*)(chan->conn->handshake_state->
                       authenticated_peer_id)));
+        /* If the client never authenticated, it's a tor client or bridge
+         * relay, and we must not use it for EXTEND requests (nor could we, as
+         * there are no authenticated peer IDs) */
+        channel_mark_client(TLS_CHAN_TO_BASE(chan));
         channel_set_circid_type(TLS_CHAN_TO_BASE(chan), NULL,
                chan->conn->link_proto < MIN_LINK_PROTO_FOR_WIDE_CIRC_IDS);
 

--- a/src/or/command.c
+++ b/src/or/command.c
@@ -344,8 +344,14 @@ command_process_create_cell(cell_t *cell, channel_t *chan)
     int len;
     created_cell_t created_cell;
 
-    /* Make sure we never try to use the OR connection on which we
-     * received this cell to satisfy an EXTEND request,  */
+    /* If the client used CREATE_FAST, it's probably a tor client or bridge
+     * relay, and we must not use it for EXTEND requests (in most cases, we
+     * won't have an authenticated peer ID for the extend).
+     * Public relays on 0.2.9 and later will use CREATE_FAST if they have no
+     * ntor onion key for this relay, but that should be a rare occurrence.
+     * Clients on 0.3.1 and later avoid using CREATE_FAST as much as they can,
+     * even during bootstrap, so the CREATE_FAST check is most accurate for
+     * earlier tor client versions. */
     channel_mark_client(chan);
 
     memset(&created_cell, 0, sizeof(created_cell));

--- a/src/or/command.c
+++ b/src/or/command.c
@@ -574,9 +574,7 @@ command_process_destroy_cell(cell_t *cell, channel_t *chan)
   if (!CIRCUIT_IS_ORIGIN(circ) &&
       chan == TO_OR_CIRCUIT(circ)->p_chan &&
       cell->circ_id == TO_OR_CIRCUIT(circ)->p_circ_id) {
-    if(!CIRCUIT_IS_ORIGIN(circ)) {
-        control_event_privcount_circuit_ended(TO_OR_CIRCUIT(circ));
-    }
+    control_event_privcount_circuit_ended(TO_OR_CIRCUIT(circ));
     /* the destroy came from behind */
     circuit_set_p_circid_chan(TO_OR_CIRCUIT(circ), 0, NULL);
     circuit_mark_for_close(circ, reason|END_CIRC_REASON_FLAG_REMOTE);

--- a/src/or/connection.c
+++ b/src/or/connection.c
@@ -3624,8 +3624,12 @@ connection_read_to_buf(connection_t *conn, ssize_t *max_to_read,
       /* Filter out directory data (at the directory).
        * Avoid updating the counters if we will never use them. */
       if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
-        privcount_sum(&exitconn->privcount_n_read, n_read);
-        privcount_sum(&orcirc->privcount_n_read, n_read);
+        exitconn->privcount_n_read = privcount_add_saturating(
+                                                  exitconn->privcount_n_read,
+                                                  n_read);
+        orcirc->privcount_n_read = privcount_add_saturating(
+                                                  orcirc->privcount_n_read,
+                                                  n_read);
       }
       if (privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
         control_event_privcount_stream_data_xferred(exitconn, orcirc,
@@ -3931,8 +3935,12 @@ connection_handle_write_impl(connection_t *conn, int force)
     /* Filter out directory data (at the directory).
      * Avoid updating the counters if we will never use them. */
     if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
-      privcount_sum(&exitconn->privcount_n_written, n_written);
-      privcount_sum(&orcirc->privcount_n_written, n_written);
+      exitconn->privcount_n_written = privcount_add_saturating(
+                                                exitconn->privcount_n_written,
+                                                n_written);
+      orcirc->privcount_n_written = privcount_add_saturating(
+                                                orcirc->privcount_n_written,
+                                                n_written);
     }
     if (privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
       control_event_privcount_stream_data_xferred(exitconn, orcirc,

--- a/src/or/connection.c
+++ b/src/or/connection.c
@@ -3622,7 +3622,7 @@ connection_read_to_buf(connection_t *conn, ssize_t *max_to_read,
       or_circuit_t* orcirc = privcount_get_or_circuit(exitconn, NULL);
 
       /* Filter out directory data (at the directory) */
-      if (privcount_is_counted_for_bytes(exitconn, orcirc)) {
+      if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
         privcount_sum(&exitconn->privcount_n_read, n_read);
         privcount_sum(&orcirc->privcount_n_read, n_read);
         control_event_privcount_stream_data_xferred(exitconn, orcirc,
@@ -3926,7 +3926,7 @@ connection_handle_write_impl(connection_t *conn, int force)
     or_circuit_t* orcirc = privcount_get_or_circuit(exitconn, NULL);
 
     /* Filter out directory data (at the directory) */
-    if (privcount_is_counted_for_bytes(exitconn, orcirc)) {
+    if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
       privcount_sum(&exitconn->privcount_n_written, n_written);
       privcount_sum(&orcirc->privcount_n_written, n_written);
       control_event_privcount_stream_data_xferred(exitconn, orcirc,

--- a/src/or/connection.c
+++ b/src/or/connection.c
@@ -825,9 +825,7 @@ connection_mark_for_close_internal_, (connection_t *conn,
               "Calling connection_mark_for_close_internal_() on an OR conn "
               "at %s:%d",
               file, line);
-    if(get_options()->EnablePrivCount) {
-      control_event_privcount_connection_ended(TO_OR_CONN(conn));
-    }
+    control_event_privcount_connection_ended(TO_OR_CONN(conn));
   }
 
   conn->marked_for_close = line;
@@ -3619,31 +3617,17 @@ connection_read_to_buf(connection_t *conn, ssize_t *max_to_read,
       }
     }
 
-    if (get_options()->EnablePrivCount && conn->type == CONN_TYPE_EXIT) {
-        /* count streams and circ bandwidth for streams at exit */
-        edge_connection_t *edge_conn = TO_EDGE_CONN(conn);
-        circuit_t *circ = circuit_get_by_edge_conn(edge_conn);
+    if (n_read > 0 && conn->type == CONN_TYPE_EXIT) {
+      edge_connection_t *exitconn = TO_EDGE_CONN(conn);
+      or_circuit_t* orcirc = privcount_get_or_circuit(exitconn, NULL);
 
-        if(circ && CIRCUIT_IS_ORCIRC(circ)) {
-            if (PREDICT_LIKELY(UINT64_MAX - edge_conn->privcount_n_read > n_read))
-                edge_conn->privcount_n_read += (uint64_t)n_read;
-            else
-                edge_conn->privcount_n_read = UINT64_MAX;
-
-            or_circuit_t* orcirc = TO_OR_CIRCUIT(circ);
-            control_event_privcount_stream_data_xferred(edge_conn, (uint64_t)n_read, 0);
-            if(edge_conn->is_dns_request) {
-                if (PREDICT_LIKELY(UINT64_MAX - orcirc->privcount_n_read_dns > n_read))
-                    orcirc->privcount_n_read_dns += (uint64_t)n_read;
-                else
-                    orcirc->privcount_n_read_dns = UINT64_MAX;
-            } else if(conn->type == CONN_TYPE_EXIT) {
-                if (PREDICT_LIKELY(UINT64_MAX - orcirc->privcount_n_read_exit > n_read))
-                    orcirc->privcount_n_read_exit += (uint64_t)n_read;
-                else
-                    orcirc->privcount_n_read_exit = UINT64_MAX;
-            }
-        }
+      /* Filter out directory data (at the directory) */
+      if (privcount_is_counted_for_bytes(exitconn, orcirc)) {
+        privcount_sum(&exitconn->privcount_n_read, n_read);
+        privcount_sum(&orcirc->privcount_n_read, n_read);
+        control_event_privcount_stream_data_xferred(exitconn, orcirc,
+                                                    n_read, 0);
+      }
     }
 
     /* If CONN_BW events are enabled, update conn->n_read_conn_bw for
@@ -3937,31 +3921,17 @@ connection_handle_write_impl(connection_t *conn, int force)
     }
   }
 
-  if (n_written > 0 && get_options()->EnablePrivCount && conn->type == CONN_TYPE_EXIT) {
-      /* count streams and circ bandwidth for streams at exit */
-      edge_connection_t *edge_conn = TO_EDGE_CONN(conn);
-      circuit_t *circ = circuit_get_by_edge_conn(edge_conn);
+  if (n_written > 0 && conn->type == CONN_TYPE_EXIT) {
+    edge_connection_t *exitconn = TO_EDGE_CONN(conn);
+    or_circuit_t* orcirc = privcount_get_or_circuit(exitconn, NULL);
 
-      if(circ && CIRCUIT_IS_ORCIRC(circ)) {
-          if (PREDICT_LIKELY(UINT64_MAX - edge_conn->privcount_n_written > n_written))
-              edge_conn->privcount_n_written += (uint64_t)n_written;
-          else
-              edge_conn->privcount_n_written = UINT64_MAX;
-
-          or_circuit_t* orcirc = TO_OR_CIRCUIT(circ);
-          control_event_privcount_stream_data_xferred(edge_conn, (uint64_t)n_written, 1);
-          if(edge_conn->is_dns_request) {
-              if (PREDICT_LIKELY(UINT64_MAX - orcirc->privcount_n_written_dns > n_written))
-                  orcirc->privcount_n_written_dns += (uint64_t)n_written;
-              else
-                  orcirc->privcount_n_written_dns = UINT64_MAX;
-          } else if(conn->type == CONN_TYPE_EXIT) {
-              if (PREDICT_LIKELY(UINT64_MAX - orcirc->privcount_n_written_exit > n_written))
-                  orcirc->privcount_n_written_exit += (uint64_t)n_written;
-              else
-                  orcirc->privcount_n_written_exit = UINT64_MAX;
-          }
-      }
+    /* Filter out directory data (at the directory) */
+    if (privcount_is_counted_for_bytes(exitconn, orcirc)) {
+      privcount_sum(&exitconn->privcount_n_written, n_written);
+      privcount_sum(&orcirc->privcount_n_written, n_written);
+      control_event_privcount_stream_data_xferred(exitconn, orcirc,
+                                                  n_written, 1);
+    }
   }
 
   /* If CONN_BW events are enabled, update conn->n_written_conn_bw for

--- a/src/or/connection.c
+++ b/src/or/connection.c
@@ -3621,10 +3621,13 @@ connection_read_to_buf(connection_t *conn, ssize_t *max_to_read,
       edge_connection_t *exitconn = TO_EDGE_CONN(conn);
       or_circuit_t* orcirc = privcount_get_or_circuit(exitconn, NULL);
 
-      /* Filter out directory data (at the directory) */
+      /* Filter out directory data (at the directory).
+       * Avoid updating the counters if we will never use them. */
       if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
         privcount_sum(&exitconn->privcount_n_read, n_read);
         privcount_sum(&orcirc->privcount_n_read, n_read);
+      }
+      if (privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
         control_event_privcount_stream_data_xferred(exitconn, orcirc,
                                                     n_read, 0);
       }
@@ -3925,10 +3928,13 @@ connection_handle_write_impl(connection_t *conn, int force)
     edge_connection_t *exitconn = TO_EDGE_CONN(conn);
     or_circuit_t* orcirc = privcount_get_or_circuit(exitconn, NULL);
 
-    /* Filter out directory data (at the directory) */
+    /* Filter out directory data (at the directory).
+     * Avoid updating the counters if we will never use them. */
     if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
       privcount_sum(&exitconn->privcount_n_written, n_written);
       privcount_sum(&orcirc->privcount_n_written, n_written);
+    }
+    if (privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
       control_event_privcount_stream_data_xferred(exitconn, orcirc,
                                                   n_written, 1);
     }

--- a/src/or/connection_or.c
+++ b/src/or/connection_or.c
@@ -1525,13 +1525,6 @@ connection_or_check_valid_tls_handshake(or_connection_t *conn,
              safe_address, conn->base_.port);
     return -1;
   } else if (!has_cert) {
-    /* If there's no channel, something is very wrong */
-    if (BUG(!conn->chan))
-      return -1;
-    /* If the client never provided a certificate, it's a tor client or bridge
-     * relay, and we must not use it for EXTEND requests (nor could we, as
-     * there is no peer certiticate) */
-    channel_mark_client(TLS_CHAN_TO_BASE(conn->chan));
     log_debug(LD_HANDSHAKE,"Got incoming connection with no certificate. "
               "That's ok.");
   }

--- a/src/or/connection_or.c
+++ b/src/or/connection_or.c
@@ -1525,6 +1525,13 @@ connection_or_check_valid_tls_handshake(or_connection_t *conn,
              safe_address, conn->base_.port);
     return -1;
   } else if (!has_cert) {
+    /* If there's no channel, something is very wrong */
+    if (BUG(!conn->chan))
+      return -1;
+    /* If the client never provided a certificate, it's a tor client or bridge
+     * relay, and we must not use it for EXTEND requests (nor could we, as
+     * there is no peer certiticate) */
+    channel_mark_client(TLS_CHAN_TO_BASE(conn->chan));
     log_debug(LD_HANDSHAKE,"Got incoming connection with no certificate. "
               "That's ok.");
   }

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -5862,7 +5862,7 @@ privcount_circuit_is_dir(const circuit_t *circ)
 /* Are conn or circ directory-related, and do they end at this relay?
  * NULL connections or circuits are not classified as directory-related. */
 static int
-privcount_is_dir(const connection_t* conn, const circuit_t *circ)
+privcount_data_is_dir(const connection_t* conn, const circuit_t *circ)
 {
   int conn_is_dir = privcount_connection_is_dir(conn);
   int circ_is_dir = privcount_circuit_is_dir(circ);
@@ -5887,7 +5887,7 @@ privcount_is_dir(const connection_t* conn, const circuit_t *circ)
  * DNS resolve is meaningless.
  * NULL connections are not classified as DNS connections. */
 static int
-privcount_conn_is_dns_resolve(const connection_t* conn)
+privcount_connection_is_dns_resolve(const connection_t* conn)
 {
   if (!conn) {
     return 0;
@@ -5947,8 +5947,8 @@ privcount_get_const_or_circuit(const edge_connection_t* exitconn,
 /* Are conn or circ Exit (or BEGINDIR), and do they end at this relay?
  * NULL connections or circuits are not classified as Exit-related. */
 static int
-privcount_is_exit(const edge_connection_t* exitconn,
-                  const or_circuit_t *orcirc)
+privcount_data_is_exit(const edge_connection_t* exitconn,
+                       const or_circuit_t *orcirc)
 {
   if (!exitconn) {
     return 0;
@@ -5980,10 +5980,10 @@ privcount_is_exit(const edge_connection_t* exitconn,
  * NULL connections or circuits are not classified as overhead.
  */
 static int
-privcount_is_overhead(const connection_t* conn, const circuit_t *circ)
+privcount_data_is_overhead(const connection_t* conn, const circuit_t *circ)
 {
 #if PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD
-  if (privcount_conn_is_dns_resolve(conn)) {
+  if (privcount_connection_is_dns_resolve(conn)) {
     return 1;
   }
 #endif
@@ -5994,15 +5994,15 @@ privcount_is_overhead(const connection_t* conn, const circuit_t *circ)
     return 1;
   }
 
-  return privcount_is_dir(conn, circ);
+  return privcount_data_is_dir(conn, circ);
 }
 
 /* Should PrivCount count streams and bytes from this connection and circuit?
  * If orcirc is NULL, it is looked up from exitconn.
  * If exitconn is NULL, returns 0. */
 int
-privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
-                               const or_circuit_t *orcirc)
+privcount_data_is_used_for_byte_counters(const edge_connection_t* exitconn,
+                                         const or_circuit_t *orcirc)
 {
   /* Ignore events that are disabled */
   if (!get_options()->EnablePrivCount) {
@@ -6019,12 +6019,12 @@ privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
     return 0;
   }
 
-  if (privcount_is_overhead(TO_CONN(exitconn), TO_CIRCUIT(orcirc))) {
+  if (privcount_data_is_overhead(TO_CONN(exitconn), TO_CIRCUIT(orcirc))) {
     return 0;
   }
 
   /* Bytes are only counted at exit connections */
-  return privcount_is_exit(exitconn, orcirc);
+  return privcount_data_is_exit(exitconn, orcirc);
 }
 
 /* Should PrivCount count cells, circuits, and connections from this
@@ -6032,8 +6032,8 @@ privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
  * Either circ or conn may be NULL, if they are, the other is used.
  * If both are NULL, returns 0. */
 int
-privcount_is_counted_for_cells(const connection_t *conn,
-                               const circuit_t *circ)
+privcount_data_is_used_for_cell_counters(const connection_t *conn,
+                                         const circuit_t *circ)
 {
   /* Ignore events that are disabled */
   if (!get_options()->EnablePrivCount) {
@@ -6050,7 +6050,7 @@ privcount_is_counted_for_cells(const connection_t *conn,
     return 0;
   }
 
-  if (privcount_is_overhead(conn, circ)) {
+  if (privcount_data_is_overhead(conn, circ)) {
     return 0;
   }
 
@@ -6061,8 +6061,8 @@ privcount_is_counted_for_cells(const connection_t *conn,
 /* Should PrivCount ignore DNS requests from this connection or circuit?
  * If orcirc or exitconn are NULL, returns 0. */
 int
-privcount_is_counted_for_dns(const edge_connection_t* exitconn,
-                             const or_circuit_t *orcirc)
+privcount_data_is_used_for_dns_counters(const edge_connection_t* exitconn,
+                                        const or_circuit_t *orcirc)
 {
   /* Ignore events that are disabled */
   if (!get_options()->EnablePrivCount) {
@@ -6079,11 +6079,11 @@ privcount_is_counted_for_dns(const edge_connection_t* exitconn,
   }
 
   /* DNS connections are never directory connections */
-  int is_dir = privcount_is_dir(TO_CONN(exitconn), TO_CIRCUIT(orcirc));
+  int is_dir = privcount_data_is_dir(TO_CONN(exitconn), TO_CIRCUIT(orcirc));
   tor_assert_nonfatal(!is_dir);
 
   /* DNS is only available at exit connections */
-  return privcount_is_exit(exitconn, orcirc);
+  return privcount_data_is_exit(exitconn, orcirc);
 }
 
 /* Is the remote end of chan a relay in our current consensus?
@@ -6201,7 +6201,7 @@ control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
     }
 
     /* Filter out directory data (at the directory) and non-exit connections */
-    if (privcount_is_counted_for_dns(exitconn, orcirc)) {
+    if (privcount_data_is_used_for_dns_counters(exitconn, orcirc)) {
         return;
     }
 
@@ -6272,7 +6272,7 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
     /* only collect stream info from exits to legitimate client-bound destinations.
      * this means we won't get hidden-service requests, directory requests, or
      * any non-exit connections */
-    if (privcount_is_counted_for_bytes(exitconn, orcirc)) {
+    if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
       return;
     }
 
@@ -6312,7 +6312,7 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
     orcirc->privcount_event_emitted = 1;
 
     /* Filter out circuit overhead (directory circuits at directories) */
-    if (privcount_is_counted_for_cells(NULL, TO_CIRCUIT(orcirc))) {
+    if (privcount_data_is_used_for_cell_counters(NULL, TO_CIRCUIT(orcirc))) {
       return;
     }
 
@@ -6361,7 +6361,7 @@ control_event_privcount_connection_ended(const or_connection_t *orconn)
     }
 
     /* Filter out connection overhead (directory connections at directories) */
-    if (privcount_is_counted_for_cells(TO_CONN(orconn), NULL)) {
+    if (privcount_data_is_used_for_cell_counters(TO_CONN(orconn), NULL)) {
       return;
     }
 

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -5868,13 +5868,15 @@ void control_event_privcount_stream_ended(edge_connection_t *conn) {
     //CIRCUIT_PURPOSE_IS_CLIENT(circ->purpose)
 
     /* only collect stream info from exits to legitimate client-bound destinations.
-     * this means we wont get hidden-service related info */
+     * this means we wont get hidden-service related info or DirPort requests,
+     * but we will get BEGINDIR (directory over ORPort) requests */
     if(conn->base_.type != CONN_TYPE_EXIT) {
         return;
     }
     int is_dns = conn->is_dns_request; // means a dns lookup
-    int is_dir = (conn->dirreq_id != 0 || conn->base_.port == 1) ? 1 : 0; // means a dir request
-    //int is_dir = (conn->base_.type == CONN_TYPE_DIR) ? 1 : 0;
+    // this is the canonical way of checking for a BEGINDIR connection
+    int has_linked_dirconn = (conn->base_.linked_conn && conn->base_.linked_conn->type == CONN_TYPE_DIR);
+    int is_dir = has_linked_dirconn ? 1 : 0; // means a dir request
 
     struct timeval now;
     tor_gettimeofday(&now);

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -5794,7 +5794,8 @@ control_event_bandwidth_used(uint32_t n_read, uint32_t n_written)
   return 0;
 }
 
-/* Is conn itself a directory server connection? */
+/* Is conn itself a directory server connection?
+ * NULL connections are not classified as directory connections. */
 static int
 privcount_connection_is_dir_server_conn(const connection_t *conn) {
   /* DirPort connections, or the directory side of linked BEGINDIR connections
@@ -5803,12 +5804,12 @@ privcount_connection_is_dir_server_conn(const connection_t *conn) {
 }
 
 /* Is conn a directory connection or BEGINDIR connection that ends at this
- * relay? */
+ * relay?
+ * NULL connections are not classified as directory connections. */
 static int
 privcount_connection_is_dir(const connection_t *conn)
 {
   if (!conn) {
-    /* Assume missing connections are *not* directory connections */
     return 0;
   }
 
@@ -5839,12 +5840,12 @@ privcount_connection_is_dir(const connection_t *conn)
   return 0;
 }
 
-/* Is circ a directory circuit that ends at this relay? */
+/* Is circ a directory circuit that ends at this relay?
+ * NULL circuits are not classified as directory circuits. */
 static int
 privcount_circuit_is_dir(const circuit_t *circ)
 {
   if (!circ) {
-    /* Assume missing circuits are *not* directory circuits */
     return 0;
   }
 
@@ -5858,7 +5859,8 @@ privcount_circuit_is_dir(const circuit_t *circ)
   return 0;
 }
 
-/* Are conn or circ directory-related, and do they end at this relay? */
+/* Are conn or circ directory-related, and do they end at this relay?
+ * NULL connections or circuits are not classified as directory-related. */
 static int
 privcount_is_dir(const connection_t* conn, const circuit_t *circ)
 {
@@ -5882,12 +5884,12 @@ privcount_is_dir(const connection_t* conn, const circuit_t *circ)
 #if PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD
 /* Is conn a DNS RESOLVE, and does it end at this relay?
  * Circuits may mix DNS resolves and connects, so asking if a circuit is a
- * DNS resolve is meaningless. */
+ * DNS resolve is meaningless.
+ * NULL connections are not classified as DNS connections. */
 static int
 privcount_conn_is_dns_resolve(const connection_t* conn)
 {
   if (!conn) {
-    /* Assume missing connections are *not* DNS */
     return 0;
   }
 
@@ -5895,7 +5897,9 @@ privcount_conn_is_dns_resolve(const connection_t* conn)
 }
 #endif
 
-/* Find the circuit for orcirc or exitconn */
+/* Find the circuit for orcirc or exitconn
+ * Either orcirc or exitconn may be NULL, if they are, the other is used.
+ * If both are NULL, returns NULL. */
 static circuit_t*
 privcount_get_circuit(edge_connection_t* exitconn,
                       or_circuit_t *orcirc)
@@ -5909,7 +5913,9 @@ privcount_get_circuit(edge_connection_t* exitconn,
   }
 }
 
-/* Find the or_circuit for orcirc or exitconn */
+/* Find the or_circuit for orcirc or exitconn
+ * Either orcirc or exitconn may be NULL, if they are, the other is used.
+ * If both are NULL, or an or_circuit can not be found, returns NULL. */
 or_circuit_t*
 privcount_get_or_circuit(edge_connection_t* exitconn,
                          or_circuit_t *orcirc)
@@ -5938,20 +5944,19 @@ privcount_get_const_or_circuit(const edge_connection_t* exitconn,
                                                 (or_circuit_t *)orcirc);
 }
 
-/* Is conn an EXIT conn (or BEGINDIR conn), and does it end at this relay? */
+/* Are conn or circ Exit (or BEGINDIR), and do they end at this relay?
+ * NULL connections or circuits are not classified as Exit-related. */
 static int
 privcount_is_exit(const edge_connection_t* exitconn,
                   const or_circuit_t *orcirc)
 {
   if (!exitconn) {
-    /* Assume missing connections are *not* Exit connections */
     return 0;
   }
 
   const or_circuit_t* oc = privcount_get_const_or_circuit(exitconn, orcirc);
 
   if (!oc) {
-    /* Assume missing circuits are *not* OR circuits */
     return 0;
   }
 
@@ -5969,8 +5974,10 @@ privcount_is_exit(const edge_connection_t* exitconn,
 }
 
 /* Should PrivCount ignore events from this connection or circuit?
- * Directory connections and DNS resolves are considered overhead, so this
- * function is not suitabe for filtering EVENT_PRIVCOUNT_DNS_RESOLVED events.
+ * Directory connections are considered overhead.
+ * If PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD is 1, this function is not suitable
+ * for filtering EVENT_PRIVCOUNT_DNS_RESOLVED events.
+ * NULL connections or circuits are not classified as overhead.
  */
 static int
 privcount_is_overhead(const connection_t* conn, const circuit_t *circ)
@@ -5990,8 +5997,9 @@ privcount_is_overhead(const connection_t* conn, const circuit_t *circ)
   return privcount_is_dir(conn, circ);
 }
 
-/* Should PrivCount count streams and bytes from this connection or circuit?
- */
+/* Should PrivCount count streams and bytes from this connection and circuit?
+ * If orcirc is NULL, it is looked up from exitconn.
+ * If exitconn is NULL, returns 0. */
 int
 privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
                                const or_circuit_t *orcirc)
@@ -6019,8 +6027,10 @@ privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
   return privcount_is_exit(exitconn, orcirc);
 }
 
-/* Should PrivCount ignore cells, circuits, and connections from this circuit?
- */
+/* Should PrivCount count cells, circuits, and connections from this
+ * connection and circuit?
+ * Either circ or conn may be NULL, if they are, the other is used.
+ * If both are NULL, returns 0. */
 int
 privcount_is_counted_for_cells(const connection_t *conn,
                                const circuit_t *circ)
@@ -6049,7 +6059,7 @@ privcount_is_counted_for_cells(const connection_t *conn,
 }
 
 /* Should PrivCount ignore DNS requests from this connection or circuit?
- */
+ * If orcirc or exitconn are NULL, returns 0. */
 int
 privcount_is_counted_for_dns(const edge_connection_t* exitconn,
                              const or_circuit_t *orcirc)
@@ -6076,12 +6086,12 @@ privcount_is_counted_for_dns(const edge_connection_t* exitconn,
   return privcount_is_exit(exitconn, orcirc);
 }
 
-/* Is the remote end of chan a relay in our current consensus? */
+/* Is the remote end of chan a relay in our current consensus?
+ * If chan is NULL, returns 0. */
 static int
 privcount_is_consensus_relay(const channel_t* chan)
 {
   if (!chan) {
-    /* Assume that missing connections *aren't* a known relay */
     return 0;
   }
 
@@ -6093,12 +6103,13 @@ privcount_is_consensus_relay(const channel_t* chan)
 }
 
 /* Is the remote end of chan a client or bridge?
- * (Relays authenticate their peer IDs to us, clients and bridges do not) */
+ * (Relays authenticate their peer IDs to other relays, clients and bridges do
+ * not)
+ * If chan is NULL, returns 0. */
 static int
 privcount_is_unauthenticated_client(const channel_t *chan)
 {
   if (!chan) {
-    /* Assume that missing connections *aren't* a client */
     return 0;
   }
 
@@ -6110,7 +6121,8 @@ privcount_is_unauthenticated_client(const channel_t *chan)
   }
 }
 
-/* Is the remote end of chan a client or bridge? */
+/* Is the remote end of chan a client or bridge?
+ * If chan is NULL, returns 0. */
 static int
 privcount_is_client(const channel_t* chan)
 {
@@ -6120,6 +6132,8 @@ privcount_is_client(const channel_t* chan)
   /* Relays in the consensus should always authenticate their peer IDs with us
    */
   if (is_relay) {
+    /* TODO: make this a protocol warning: if our code is correct, it is the
+     * other side that is misbehaving */
     tor_assert_nonfatal(!is_client);
   }
 
@@ -6137,9 +6151,13 @@ privcount_add_saturating(uint64_t a, uint64_t b) {
   }
 }
 
-/* Perform a += b without overflow, and without returning a value */
+/* Perform a += b without overflow, and without returning a value
+ * total must not be NULL */
 void
 privcount_sum(uint64_t *total, uint64_t increment) {
+  if (BUG(!total)) {
+    return;
+  }
   *total = privcount_add_saturating(*total, increment);
 }
 
@@ -6172,7 +6190,8 @@ privcount_chan_addr_to_str_dup(const channel_t *chan)
 /* Send a PrivCount DNS resolution event triggered on exitconn and orcirc.
  * This event includes failed resolves, but excludes immediate results, such
  * as trivial IP address resolves and failed malformed resolves.
- * See PrivCount bug 184 for details. */
+ * See PrivCount bug 184 for details.
+ * If orcirc or exitconn are NULL, the event is ignored. */
 void
 control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
                                      const or_circuit_t *orcirc)
@@ -6203,13 +6222,19 @@ control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
 /* Send a PrivCount stream data transfer event triggered on exitconn and
  * orcirc with amt bytes.
  * If is_outbound is true, the data was written to a remote peer, otherwise,
- * the data was read from a remote peer. */
+ * the data was read from a remote peer.
+ * exitconn must not be NULL.
+ * If orcirc is NULL, it is looked up from exitconn. */
 void
 control_event_privcount_stream_data_xferred(const edge_connection_t *exitconn,
                                             const or_circuit_t *orcirc,
                                             uint64_t amt, int is_outbound)
 {
     if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED)) {
+        return;
+    }
+
+    if (BUG(!exitconn)) {
         return;
     }
 
@@ -6228,11 +6253,16 @@ control_event_privcount_stream_data_xferred(const edge_connection_t *exitconn,
             (long)now.tv_sec, (long)now.tv_usec);
 }
 
-/* Send a PrivCount stream end event triggered on exitconn. */
+/* Send a PrivCount stream end event triggered on exitconn.
+ * exitconn must not be NULL. */
 void
 control_event_privcount_stream_ended(const edge_connection_t *exitconn)
 {
     if(!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_ENDED)) {
+        return;
+    }
+
+    if (BUG(!exitconn)) {
         return;
     }
 
@@ -6264,7 +6294,8 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
 
 /* Send a PrivCount circuit end event triggered on orcirc.
  * Sets the privcount_event_emitted flag in orcirc to ensure that each
- * circuit only emits one event. */
+ * circuit only emits one event.
+ * orcirc must not be NULL. */
 void
 control_event_privcount_circuit_ended(or_circuit_t *orcirc)
 {
@@ -6272,9 +6303,9 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
         return;
     }
 
-    /* Ignore events with missing data, or events that have already been sent
+    /* Ignore events that have already been sent
      */
-    if (!orcirc || orcirc->privcount_event_emitted) {
+    if (BUG(!orcirc) || orcirc->privcount_event_emitted) {
         return;
     }
 
@@ -6316,7 +6347,8 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
     tor_free(n_addr);
 }
 
-/* Send a PrivCount connection end event triggered on orconn. */
+/* Send a PrivCount connection end event triggered on orconn.
+ * orconn must not be NULL. */
 void
 control_event_privcount_connection_ended(const or_connection_t *orconn)
 {
@@ -6324,8 +6356,7 @@ control_event_privcount_connection_ended(const or_connection_t *orconn)
         return;
     }
 
-    /* Ignore events with missing data */
-    if (!orconn) {
+    if (BUG(!orconn)) {
         return;
     }
 

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -5796,7 +5796,7 @@ control_event_bandwidth_used(uint32_t n_read, uint32_t n_written)
 
 /* Is conn itself a directory server connection? */
 static int
-privcount_connection_is_dir_server_conn(connection_t *conn) {
+privcount_connection_is_dir_server_conn(const connection_t *conn) {
   /* DirPort connections, or the directory side of linked BEGINDIR connections
    */
   return conn && conn->type == CONN_TYPE_DIR && DIR_CONN_IS_SERVER(conn);
@@ -5805,7 +5805,7 @@ privcount_connection_is_dir_server_conn(connection_t *conn) {
 /* Is conn a directory connection or BEGINDIR connection that ends at this
  * relay? */
 static int
-privcount_connection_is_dir(connection_t *conn)
+privcount_connection_is_dir(const connection_t *conn)
 {
   if (!conn) {
     /* Assume missing connections are *not* directory connections */
@@ -5841,20 +5841,10 @@ privcount_connection_is_dir(connection_t *conn)
 
 /* Is circ a directory circuit that ends at this relay? */
 static int
-privcount_circuit_is_dir(circuit_t *circ)
+privcount_circuit_is_dir(const circuit_t *circ)
 {
   if (!circ) {
     /* Assume missing circuits are *not* directory circuits */
-    return 0;
-  }
-
-  if (!CIRCUIT_IS_ORCIRC(circ)) {
-    /* Origin circuits are *not* server directory circuits */
-    return 0;
-  }
-
-  if (circ->purpose != CIRCUIT_PURPOSE_OR) {
-    /* Only OR circuits can be server directory circuits */
     return 0;
   }
 
@@ -5870,7 +5860,7 @@ privcount_circuit_is_dir(circuit_t *circ)
 
 /* Are conn or circ directory-related, and do they end at this relay? */
 static int
-privcount_is_dir(connection_t* conn, circuit_t *circ)
+privcount_is_dir(const connection_t* conn, const circuit_t *circ)
 {
   int conn_is_dir = privcount_connection_is_dir(conn);
   int circ_is_dir = privcount_circuit_is_dir(circ);
@@ -5883,102 +5873,380 @@ privcount_is_dir(connection_t* conn, circuit_t *circ)
   return conn_is_dir || circ_is_dir;
 }
 
-void control_event_privcount_dns_resolved(edge_connection_t *exitconn, or_circuit_t *oncirc) {
-    if(!get_options()->EnablePrivCount || !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_DNS_RESOLVED)) {
-        return;
-    }
+/* DNS resolves are a normal part of the Tor protocol for DNSPort/SOCKS4
+ * clients, so DNS is not considered overhead by default */
+#ifndef PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD
+#define PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD 0
+#endif
 
-    if(!oncirc || !oncirc->p_chan || !exitconn) {
-        return;
-    }
+#if PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD
+/* Is conn a DNS RESOLVE, and does it end at this relay?
+ * Circuits may mix DNS resolves and connects, so asking if a circuit is a
+ * DNS resolve is meaningless. */
+static int
+privcount_conn_is_dns_resolve(const connection_t* conn)
+{
+  if (!conn) {
+    /* Assume missing connections are *not* DNS */
+    return 0;
+  }
 
-    /* DNS connections are not directory connections */
-    int is_dir = privcount_is_dir(TO_CONN(exitconn), TO_CIRCUIT(oncirc));
-    tor_assert_nonfatal(!is_dir);
+  return conn->type == CONN_TYPE_EXIT && conn->purpose == EXIT_PURPOSE_RESOLVE;
+}
+#endif
 
-    send_control_event(EVENT_PRIVCOUNT_DNS_RESOLVED,
-                       "650 PRIVCOUNT_DNS_RESOLVED %" PRIu64 " %" PRIu32 " %s\r\n",
-                       oncirc->p_chan->global_identifier,
-                       oncirc->p_circ_id,
-                       exitconn->base_.address);
+/* Find the circuit for orcirc or exitconn */
+static circuit_t*
+privcount_get_circuit(edge_connection_t* exitconn,
+                      or_circuit_t *orcirc)
+{
+  if (orcirc) {
+    return TO_CIRCUIT(orcirc);
+  } else if (exitconn) {
+    return circuit_get_by_edge_conn(exitconn);
+  } else {
+    return NULL;
+  }
 }
 
-void control_event_privcount_stream_data_xferred(edge_connection_t *conn, uint64_t amt, int is_outbound) {
-    if(!get_options()->EnablePrivCount || !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED)) {
-        return;
+/* Find the or_circuit for orcirc or exitconn */
+or_circuit_t*
+privcount_get_or_circuit(edge_connection_t* exitconn,
+                         or_circuit_t *orcirc)
+{
+  if (orcirc) {
+    tor_assert_nonfatal(CIRCUIT_IS_ORCIRC(orcirc));
+    return orcirc;
+  } else {
+    circuit_t* circ = privcount_get_circuit(exitconn, orcirc);
+    if (circ && CIRCUIT_IS_ORCIRC(circ)) {
+      return TO_OR_CIRCUIT(circ);
+    } else {
+      return NULL;
     }
+  }
+}
 
-    if(!conn || conn->base_.type != CONN_TYPE_EXIT) {
-        return;
+/* Like privcount_get_or_circuit, but with casts that tell the compiler we're
+ * not actually modifying anything */
+static const or_circuit_t*
+privcount_get_const_or_circuit(const edge_connection_t* exitconn,
+                               const or_circuit_t *orcirc)
+{
+  return (const or_circuit_t *)privcount_get_or_circuit(
+                                                (edge_connection_t *)exitconn,
+                                                (or_circuit_t *)orcirc);
+}
+
+/* Is conn an EXIT conn (or BEGINDIR conn), and does it end at this relay? */
+static int
+privcount_is_exit(const edge_connection_t* exitconn,
+                  const or_circuit_t *orcirc)
+{
+  if (!exitconn) {
+    /* Assume missing connections are *not* Exit connections */
+    return 0;
+  }
+
+  const or_circuit_t* oc = privcount_get_const_or_circuit(exitconn, orcirc);
+
+  if (!oc) {
+    /* Assume missing circuits are *not* OR circuits */
+    return 0;
+  }
+
+  /* if the circuit started here, this is our own stream and we can ignore it
+   */
+  if (CIRCUIT_IS_ORIGIN(TO_CIRCUIT(oc))) {
+    return 0;
+  }
+
+  if (!oc->p_chan) {
+    return 0;
+  }
+
+  return TO_CONN(exitconn)->type == CONN_TYPE_EXIT;
+}
+
+/* Should PrivCount ignore events from this connection or circuit?
+ * Directory connections and DNS resolves are considered overhead, so this
+ * function is not suitabe for filtering EVENT_PRIVCOUNT_DNS_RESOLVED events.
+ */
+static int
+privcount_is_overhead(const connection_t* conn, const circuit_t *circ)
+{
+#if PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD
+  if (privcount_conn_is_dns_resolve(conn)) {
+    return 1;
+  }
+#endif
+
+  /* if the circuit started here, this is our own stream and we can ignore it
+   */
+  if (circ && CIRCUIT_IS_ORIGIN(circ)) {
+    return 1;
+  }
+
+  return privcount_is_dir(conn, circ);
+}
+
+/* Should PrivCount count streams and bytes from this connection or circuit?
+ */
+int
+privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
+                               const or_circuit_t *orcirc)
+{
+  /* Ignore events that are disabled */
+  if (!get_options()->EnablePrivCount) {
+    return 0;
+  }
+
+  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED) &&
+      !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_ENDED)) {
+    return 0;
+  }
+
+  /* Ignore events with missing connections */
+  if (!exitconn) {
+    return 0;
+  }
+
+  if (privcount_is_overhead(TO_CONN(exitconn), TO_CIRCUIT(orcirc))) {
+    return 0;
+  }
+
+  /* Bytes are only counted at exit connections */
+  return privcount_is_exit(exitconn, orcirc);
+}
+
+/* Should PrivCount ignore cells, circuits, and connections from this circuit?
+ */
+int
+privcount_is_counted_for_cells(const connection_t *conn,
+                               const circuit_t *circ)
+{
+  /* Ignore events that are disabled */
+  if (!get_options()->EnablePrivCount) {
+    return 0;
+  }
+
+  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CIRCUIT_ENDED) &&
+      !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CONNECTION_ENDED)) {
+    return 0;
+  }
+
+  /* Ignore events which are missing both connection and circuit */
+  if (!conn && !circ) {
+    return 0;
+  }
+
+  if (privcount_is_overhead(conn, circ)) {
+    return 0;
+  }
+
+  /* Cells get counted at non-exit connections as well as exit connections */
+  return 1;
+}
+
+/* Should PrivCount ignore DNS requests from this connection or circuit?
+ */
+int
+privcount_is_counted_for_dns(const edge_connection_t* exitconn,
+                             const or_circuit_t *orcirc)
+{
+  /* Ignore events that are disabled */
+  if (!get_options()->EnablePrivCount) {
+    return 0;
+  }
+
+  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_DNS_RESOLVED)) {
+    return 0;
+  }
+
+  /* Ignore events with incomplete data */
+  if (!exitconn || !orcirc) {
+    return 0;
+  }
+
+  /* DNS connections are never directory connections */
+  int is_dir = privcount_is_dir(TO_CONN(exitconn), TO_CIRCUIT(orcirc));
+  tor_assert_nonfatal(!is_dir);
+
+  /* DNS is only available at exit connections */
+  return privcount_is_exit(exitconn, orcirc);
+}
+
+/* Is the remote end of chan a relay in our current consensus? */
+static int
+privcount_is_consensus_relay(const channel_t* chan)
+{
+  if (!chan) {
+    /* Assume that missing connections *aren't* a known relay */
+    return 0;
+  }
+
+  if (connection_or_digest_is_known_relay(chan->identity_digest)) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+/* Is the remote end of chan a client or bridge?
+ * (Relays authenticate their peer IDs to us, clients and bridges do not) */
+static int
+privcount_is_unauthenticated_client(const channel_t *chan)
+{
+  if (!chan) {
+    /* Assume that missing connections *aren't* a client */
+    return 0;
+  }
+
+  /* channel_is_client doesn't actually modify chan */
+  if (channel_is_client((channel_t *)chan)) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+/* Is the remote end of chan a client or bridge? */
+static int
+privcount_is_client(const channel_t* chan)
+{
+  int is_relay = privcount_is_consensus_relay(chan);
+  int is_client = privcount_is_unauthenticated_client(chan);
+
+  /* Relays in the consensus should always authenticate their peer IDs with us
+   */
+  if (is_relay) {
+    tor_assert_nonfatal(!is_client);
+  }
+
+  /* is_client is more reliable, but only with the fix for Tor bug 21406 */
+  return is_client && !is_relay;
+}
+
+/* Perform a 64-bit saturating add of a and b */
+static uint64_t
+privcount_add_saturating(uint64_t a, uint64_t b) {
+  if (PREDICT_LIKELY(UINT64_MAX - a > b)) {
+    return a + b;
+  } else {
+    return UINT64_MAX;
+  }
+}
+
+/* Perform a += b without overflow, and without returning a value */
+void
+privcount_sum(uint64_t *total, uint64_t increment) {
+  *total = privcount_add_saturating(*total, increment);
+}
+
+#define NO_CHANNEL_ADDRESS "0.0.0.0"
+#define NO_CONNECTION_ADDRESS "0.0.0.0"
+
+/* Return a newly allocated string containing the remote address of chan,
+ * or a placeholder if chan is NULL or has no connection.
+ * The returned string must be freed using tor_free(). */
+static char *
+privcount_chan_addr_to_str_dup(const channel_t *chan)
+{
+  /* channel_get_actual_remote_address / channel_tls_get_remote_descr_method
+   * can't be used here, because it uses a static buffer */
+  if (chan) {
+    tor_addr_t addr;
+    int has_addr;
+    /* channel_tls_get_remote_addr_method does not actually modify chan */
+    has_addr = channel_get_addr_if_possible((channel_t *)chan, &addr);
+    if (has_addr) {
+      return tor_addr_to_str_dup(&addr);
+    } else {
+      return tor_strdup(NO_CONNECTION_ADDRESS);
     }
+  } else {
+    return tor_strdup(NO_CHANNEL_ADDRESS);
+  }
+}
 
-    /* if the circuit started here, this is our own stream and we can ignore it */
-    circuit_t* circ = circuit_get_by_edge_conn(conn);
-    or_circuit_t *orcirc = NULL;
-    if(circ) {
-        if(CIRCUIT_IS_ORIGIN(circ)) {
-            return;
-        }
-        /* now we know its an or_circuit_t */
-        orcirc = TO_OR_CIRCUIT(circ);
-    }
-
-    struct timeval now;
-    tor_gettimeofday(&now);
-
-    /* Filter out directory data */
-    int is_dir = privcount_is_dir(TO_CONN(conn), circ);
-    if (is_dir) {
+/* Send a PrivCount DNS resolution event triggered on exitconn and orcirc.
+ * This event includes failed resolves, but excludes immediate results, such
+ * as trivial IP address resolves and failed malformed resolves.
+ * See PrivCount bug 184 for details. */
+void
+control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
+                                     const or_circuit_t *orcirc)
+{
+    if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_DNS_RESOLVED)) {
       return;
     }
 
-    /* ChanID, CircID, StreamID, BW, Direction, Time */
+    /* Filter out directory data (at the directory) and non-exit connections */
+    if (privcount_is_counted_for_dns(exitconn, orcirc)) {
+        return;
+    }
+
+    /* There's no time here. We should fix that if we ever use this event */
+#if 0
+    /* Get the time as early as possible, but after we're sure we want it */
+    struct timeval now;
+    tor_gettimeofday(&now);
+#endif
+
+    send_control_event(EVENT_PRIVCOUNT_DNS_RESOLVED,
+                       "650 PRIVCOUNT_DNS_RESOLVED %" PRIu64 " %" PRIu32 " %s\r\n",
+                       orcirc->p_chan->global_identifier,
+                       orcirc->p_circ_id,
+                       exitconn->base_.address);
+}
+
+/* Send a PrivCount stream data transfer event triggered on exitconn and
+ * orcirc with amt bytes.
+ * If is_outbound is true, the data was written to a remote peer, otherwise,
+ * the data was read from a remote peer. */
+void
+control_event_privcount_stream_data_xferred(const edge_connection_t *exitconn,
+                                            const or_circuit_t *orcirc,
+                                            uint64_t amt, int is_outbound)
+{
+    if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED)) {
+        return;
+    }
+
+    /* Get the time as early as possible, but after we're sure we want it */
+    struct timeval now;
+    tor_gettimeofday(&now);
+
+    /* ChanID, CircID, StreamID, Direction, BW, Time */
     send_control_event(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED,
             "650 PRIVCOUNT_STREAM_BYTES_TRANSFERRED %"PRIu64" %"PRIu32" %"PRIu16" %d %"PRIu64" %ld.%06ld\r\n",
             orcirc && orcirc->p_chan ? orcirc->p_chan->global_identifier : 0,
             orcirc ? orcirc->p_circ_id : 0,
-            conn->stream_id,
+            exitconn->stream_id,
             is_outbound,
             amt,
             (long)now.tv_sec, (long)now.tv_usec);
 }
 
-void control_event_privcount_stream_ended(edge_connection_t *conn) {
-    if(!get_options()->EnablePrivCount || !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_ENDED)) {
+/* Send a PrivCount stream end event triggered on exitconn. */
+void
+control_event_privcount_stream_ended(const edge_connection_t *exitconn)
+{
+    if(!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_ENDED)) {
         return;
     }
 
-    if(!conn) {
-        return;
-    }
-
-    /* if the circuit started here, this is our own stream and we can ignore it */
-    circuit_t* circ = circuit_get_by_edge_conn(conn);
-    or_circuit_t *orcirc = NULL;
-    if(circ) {
-        if(CIRCUIT_IS_ORIGIN(circ)) {
-            return;
-        }
-        /* now we know its an or_circuit_t */
-        orcirc = TO_OR_CIRCUIT(circ);
-    }
-
-    /* to exclude hidden-service "server" circuits, use this */
-    //CIRCUIT_PURPOSE_IS_CLIENT(circ->purpose)
+    const or_circuit_t* orcirc = privcount_get_const_or_circuit(exitconn,
+                                                                NULL);
 
     /* only collect stream info from exits to legitimate client-bound destinations.
-     * this means we won't get hidden-service related info or DirPort requests,
-     * but we will get BEGINDIR (directory over ORPort) requests */
-    if(conn->base_.type != CONN_TYPE_EXIT) {
-        return;
-    }
-    int is_dns = conn->is_dns_request; // means a dns lookup
-    /* Filter out directory streams */
-    int is_dir = privcount_is_dir(TO_CONN(conn), circ);
-    if (is_dir) {
+     * this means we won't get hidden-service requests, directory requests, or
+     * any non-exit connections */
+    if (privcount_is_counted_for_bytes(exitconn, orcirc)) {
       return;
     }
 
+    /* Get the time as early as possible, but after we're sure we want it */
     struct timeval now;
     tor_gettimeofday(&now);
 
@@ -5987,105 +6255,104 @@ void control_event_privcount_stream_ended(edge_connection_t *conn) {
             "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld %d %d\r\n",
             orcirc && orcirc->p_chan ? orcirc->p_chan->global_identifier : 0,
             orcirc ? orcirc->p_circ_id : 0,
-            conn->stream_id, conn->base_.port,
-            conn->privcount_n_read, conn->privcount_n_written,
-            (long)conn->base_.timestamp_created_tv.tv_sec, (long)conn->base_.timestamp_created_tv.tv_usec,
+            exitconn->stream_id, exitconn->base_.port,
+            exitconn->privcount_n_read, exitconn->privcount_n_written,
+            (long)exitconn->base_.timestamp_created_tv.tv_sec, (long)exitconn->base_.timestamp_created_tv.tv_usec,
             (long)now.tv_sec, (long)now.tv_usec,
-            is_dns, is_dir);
+            0, 0);
 }
 
-void control_event_privcount_circuit_ended(or_circuit_t *orcirc) {
-    if(!get_options()->EnablePrivCount || !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CIRCUIT_ENDED)) {
+/* Send a PrivCount circuit end event triggered on orcirc.
+ * Sets the privcount_event_emitted flag in orcirc to ensure that each
+ * circuit only emits one event. */
+void
+control_event_privcount_circuit_ended(or_circuit_t *orcirc)
+{
+    if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CIRCUIT_ENDED)) {
         return;
     }
 
-    if(!orcirc || orcirc->privcount_event_emitted) {
+    /* Ignore events with missing data, or events that have already been sent
+     */
+    if (!orcirc || orcirc->privcount_event_emitted) {
         return;
-    }
-
-    /* only collect circuit info from first hops on circuits that were actually used
-     * we already know this is not an origin circ since we have a or_circuit_t struct */
-    int prev_is_client = 0, prev_is_relay = 0;
-    if(orcirc->p_chan) {
-        if(connection_or_digest_is_known_relay(orcirc->p_chan->identity_digest)) {
-            prev_is_relay = 1;
-        } else if(orcirc->p_chan->is_client) {
-            prev_is_client = 1;
-        }
-    }
-
-    int next_is_client = 0, next_is_relay = 0;
-    if(orcirc->base_.n_chan) {
-        if(connection_or_digest_is_known_relay(orcirc->base_.n_chan->identity_digest)) {
-            next_is_relay = 1;
-        } else if(orcirc->base_.n_chan->is_client) {
-            next_is_client = 1;
-        }
     }
 
     orcirc->privcount_event_emitted = 1;
 
+    /* Filter out circuit overhead (directory circuits at directories) */
+    if (privcount_is_counted_for_cells(NULL, TO_CIRCUIT(orcirc))) {
+      return;
+    }
+
+    /* Get the time as early as possible, but after we're sure we want it */
     struct timeval now;
     tor_gettimeofday(&now);
 
-    /* Filter out directory circuits */
-    int is_dir = privcount_is_dir(NULL, TO_CIRCUIT(orcirc));
-    if (is_dir) {
-      return;
-    }
+    /* only collect circuit info from first hops on circuits that were actually used
+     * we already know this is not an origin circ since we have a or_circuit_t struct */
+    tor_assert_nonfatal(orcirc->p_chan);
+    int prev_is_client = privcount_is_client(orcirc->p_chan);
+    int next_is_client = privcount_is_client(orcirc->base_.n_chan);
+
+    char *p_addr = privcount_chan_addr_to_str_dup(orcirc->p_chan);
+    char *n_addr = privcount_chan_addr_to_str_dup(orcirc->base_.n_chan);
 
     /* ChanID, CircID, nCellsIn, nCellsOut, ReadBWDNS, WriteBWDNS, ReadBWExit, WriteBWExit, TimeStart, TimeEnd, PrevIP, prevIsClient, prevIsRelay, NextIP, nextIsClient, nextIsRelay */
     send_control_event(EVENT_PRIVCOUNT_CIRCUIT_ENDED,
             "650 PRIVCOUNT_CIRCUIT_ENDED %"PRIu64" %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld %s %d %d %s %d %d\r\n",
             orcirc->p_chan ? orcirc->p_chan->global_identifier : 0, orcirc->p_circ_id,
             orcirc->privcount_n_cells_in, orcirc->privcount_n_cells_out,
-            orcirc->privcount_n_read_dns, orcirc->privcount_n_written_dns,
-            orcirc->privcount_n_read_exit, orcirc->privcount_n_written_exit,
+            (uint64_t)0, (uint64_t)0,
+            orcirc->privcount_n_read, orcirc->privcount_n_written,
             (long)orcirc->base_.timestamp_created.tv_sec, (long)orcirc->base_.timestamp_created.tv_usec,
             (long)now.tv_sec, (long)now.tv_usec,
-            orcirc->p_chan ? channel_get_actual_remote_address(orcirc->p_chan) : "0.0.0.0",
-            prev_is_client, prev_is_relay,
-            orcirc->base_.n_chan ? channel_get_actual_remote_address(orcirc->base_.n_chan) : "0.0.0.0",
-            next_is_client, next_is_relay);
+            p_addr,
+            prev_is_client, !prev_is_client,
+            n_addr,
+            next_is_client, !next_is_client);
+
+    tor_free(p_addr);
+    tor_free(n_addr);
 }
 
-void control_event_privcount_connection_ended(or_connection_t *orconn) {
-    if(!get_options()->EnablePrivCount || !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CONNECTION_ENDED)) {
+/* Send a PrivCount connection end event triggered on orconn. */
+void
+control_event_privcount_connection_ended(const or_connection_t *orconn)
+{
+    if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CONNECTION_ENDED)) {
         return;
     }
 
-    if(!orconn) {
+    /* Ignore events with missing data */
+    if (!orconn) {
         return;
     }
 
-    channel_t* p_chan = (channel_t*)orconn->chan;
-
-    int is_client = 0, is_relay = 0;
-    if(p_chan) {
-        if(connection_or_digest_is_known_relay(p_chan->identity_digest)) {
-            is_relay = 1;
-        } else if(p_chan->is_client) {
-            is_client = 1;
-        }
+    /* Filter out connection overhead (directory connections at directories) */
+    if (privcount_is_counted_for_cells(TO_CONN(orconn), NULL)) {
+      return;
     }
 
+    /* Get the time as early as possible, but after we're sure we want it */
     struct timeval now;
     tor_gettimeofday(&now);
 
-    /* Filter out directory connections */
-    int is_dir = privcount_is_dir(TO_CONN(orconn), NULL);
-    if (is_dir) {
-      return;
-    }
+    const channel_t *chan = TLS_CHAN_TO_BASE(orconn->chan);
+    int is_client = privcount_is_client(chan);
+
+    char *addr = privcount_chan_addr_to_str_dup(chan);
 
     /* ChanID, TimeStart, TimeEnd, IP, isClient, isRelay */
     send_control_event(EVENT_PRIVCOUNT_CONNECTION_ENDED,
             "650 PRIVCOUNT_CONNECTION_ENDED %"PRIu64" %ld.%06ld %ld.%06ld %s %d %d\r\n",
-            p_chan ? p_chan->global_identifier : 0,
+            chan ? chan->global_identifier : 0,
             (long)orconn->base_.timestamp_created_tv.tv_sec, (long)orconn->base_.timestamp_created_tv.tv_usec,
             (long)now.tv_sec, (long)now.tv_usec,
-            p_chan ? channel_get_actual_remote_address(p_chan) : "0.0.0.0",
-            is_client, is_relay);
+            addr,
+            is_client, !is_client);
+
+    tor_free(addr);
 }
 
 STATIC char *

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -5973,75 +5973,18 @@ privcount_data_is_exit(const edge_connection_t* exitconn,
   return TO_CONN(exitconn)->type == CONN_TYPE_EXIT;
 }
 
-/* Should PrivCount ignore events from this connection or circuit?
- * Directory connections are considered overhead.
- * If PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD is 1, this function is not suitable
- * for filtering EVENT_PRIVCOUNT_DNS_RESOLVED events.
- * NULL connections or circuits are not classified as overhead.
+/* Should PrivCount send events and update byte and cell counts from this
+ * connection and circuit?
+ * Returns 0 for directory connections.
+ * If PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD is 1, returns 0 for DNS resolves.
+ * Either circ or conn may be NULL, if they are, the other is checked.
+ * If both are NULL, returns 0.
  */
 static int
-privcount_data_is_overhead(const connection_t* conn, const circuit_t *circ)
+privcount_data_is_used(const connection_t* conn, const circuit_t *circ)
 {
-#if PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD
-  if (privcount_connection_is_dns_resolve(conn)) {
-    return 1;
-  }
-#endif
-
-  /* if the circuit started here, this is our own stream and we can ignore it
-   */
-  if (circ && CIRCUIT_IS_ORIGIN(circ)) {
-    return 1;
-  }
-
-  return privcount_data_is_dir(conn, circ);
-}
-
-/* Should PrivCount count streams and bytes from this connection and circuit?
- * If orcirc is NULL, it is looked up from exitconn.
- * If exitconn is NULL, returns 0. */
-int
-privcount_data_is_used_for_byte_counters(const edge_connection_t* exitconn,
-                                         const or_circuit_t *orcirc)
-{
-  /* Ignore events that are disabled */
+  /* Ignore events and counters when PrivCount is disabled */
   if (!get_options()->EnablePrivCount) {
-    return 0;
-  }
-
-  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED) &&
-      !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_ENDED)) {
-    return 0;
-  }
-
-  /* Ignore events with missing connections */
-  if (!exitconn) {
-    return 0;
-  }
-
-  if (privcount_data_is_overhead(TO_CONN(exitconn), TO_CIRCUIT(orcirc))) {
-    return 0;
-  }
-
-  /* Bytes are only counted at exit connections */
-  return privcount_data_is_exit(exitconn, orcirc);
-}
-
-/* Should PrivCount count cells, circuits, and connections from this
- * connection and circuit?
- * Either circ or conn may be NULL, if they are, the other is used.
- * If both are NULL, returns 0. */
-int
-privcount_data_is_used_for_cell_counters(const connection_t *conn,
-                                         const circuit_t *circ)
-{
-  /* Ignore events that are disabled */
-  if (!get_options()->EnablePrivCount) {
-    return 0;
-  }
-
-  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CIRCUIT_ENDED) &&
-      !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CONNECTION_ENDED)) {
     return 0;
   }
 
@@ -6050,40 +5993,100 @@ privcount_data_is_used_for_cell_counters(const connection_t *conn,
     return 0;
   }
 
-  if (privcount_data_is_overhead(conn, circ)) {
+  /* if the circuit started here, this is our own stream and we can ignore it
+   */
+  if (circ && CIRCUIT_IS_ORIGIN(circ)) {
     return 0;
   }
 
-  /* Cells get counted at non-exit connections as well as exit connections */
+  if (privcount_data_is_dir(conn, circ)) {
+    return 0;
+  }
+
   return 1;
 }
 
-/* Should PrivCount ignore DNS requests from this connection or circuit?
- * If orcirc or exitconn are NULL, returns 0. */
+/* Should PrivCount send stream transfer and stream end events for this
+ * connection and circuit?
+ * If orcirc is NULL, it is looked up from exitconn.
+ * If exitconn is NULL, orcirc is checked. */
 int
-privcount_data_is_used_for_dns_counters(const edge_connection_t* exitconn,
-                                        const or_circuit_t *orcirc)
+privcount_data_is_used_for_stream_events(const edge_connection_t* exitconn,
+                                         const or_circuit_t *orcirc)
 {
-  /* Ignore events that are disabled */
-  if (!get_options()->EnablePrivCount) {
+  const or_circuit_t* oc = privcount_get_const_or_circuit(exitconn, orcirc);
+
+  if (!privcount_data_is_used(TO_CONN(exitconn), TO_CIRCUIT(oc))) {
     return 0;
   }
 
-  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_DNS_RESOLVED)) {
+  /* Bytes are only counted at exit connections */
+  return privcount_data_is_exit(exitconn, oc);
+}
+
+/* Should PrivCount count bytes for this connection and circuit?
+ * See privcount_data_is_used_for_stream_events for argument descriptions. */
+int
+privcount_data_is_used_for_byte_counters(const edge_connection_t* exitconn,
+                                         const or_circuit_t *orcirc)
+{
+  /* These events use byte counts via edge_connection_t's privcount_n_read or
+   * privcount_n_written. */
+  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_STREAM_ENDED) &&
+      !EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CIRCUIT_ENDED)) {
     return 0;
   }
 
-  /* Ignore events with incomplete data */
-  if (!exitconn || !orcirc) {
+  /* Byte counts use the same checks as stream events, even though they are
+   * reported by the stream end and circuit end events. */
+  return privcount_data_is_used_for_stream_events(exitconn, orcirc);
+}
+
+/* Should PrivCount send circuit events for this circuit?
+ * If circ is NULL, returns 0. */
+int
+privcount_data_is_used_for_circuit_events(const circuit_t *circ)
+{
+  /* Circuits have a next and previous channel, so unlike stream events,
+   * we don't look up connection(s) from the circuit. */
+  return privcount_data_is_used(NULL, circ);
+}
+
+/* Should PrivCount count cells for this circuit?
+ * See privcount_data_is_used_for_circuit_events for argument descriptions. */
+int
+privcount_data_is_used_for_cell_counters(const circuit_t *circ)
+{
+  /* These events use cell counts via edge_connection_t's privcount_n_cells_in
+   * or privcount_n_cells_out. */
+  if (!EVENT_IS_INTERESTING(EVENT_PRIVCOUNT_CIRCUIT_ENDED)) {
     return 0;
   }
 
+  /* Cell counters are only used in circuit events, so the checks are the
+   * same. */
+  return privcount_data_is_used_for_circuit_events(circ);
+}
+
+/* Should PrivCount send connection events for this connection?
+ * If conn is NULL, return 0. */
+int
+privcount_data_is_used_for_connection_events(const connection_t *conn)
+{
+  return privcount_data_is_used(conn, NULL);
+}
+
+/* Should PrivCount send DNS events from this connection or circuit?
+ * See privcount_data_is_used for argument descriptions. */
+int
+privcount_data_is_used_for_dns_events(const edge_connection_t* exitconn,
+                                      const or_circuit_t *orcirc)
+{
   /* DNS connections are never directory connections */
   int is_dir = privcount_data_is_dir(TO_CONN(exitconn), TO_CIRCUIT(orcirc));
   tor_assert_nonfatal(!is_dir);
 
-  /* DNS is only available at exit connections */
-  return privcount_data_is_exit(exitconn, orcirc);
+  return privcount_data_is_used(TO_CONN(exitconn), TO_CIRCUIT(orcirc));
 }
 
 /* Is the remote end of chan a relay in our current consensus?
@@ -6191,6 +6194,7 @@ privcount_chan_addr_to_str_dup(const channel_t *chan)
  * This event includes failed resolves, but excludes immediate results, such
  * as trivial IP address resolves and failed malformed resolves.
  * See PrivCount bug 184 for details.
+ * If PRIVCOUNT_DNS_RESOLVE_IS_OVERHEAD is 1, no DNS resolve events are sent.
  * If orcirc or exitconn are NULL, the event is ignored. */
 void
 control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
@@ -6201,7 +6205,7 @@ control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
     }
 
     /* Filter out directory data (at the directory) and non-exit connections */
-    if (privcount_data_is_used_for_dns_counters(exitconn, orcirc)) {
+    if (privcount_data_is_used_for_dns_events(exitconn, orcirc)) {
         return;
     }
 
@@ -6238,6 +6242,14 @@ control_event_privcount_stream_data_xferred(const edge_connection_t *exitconn,
         return;
     }
 
+    /* Only send stream events for connections from exits to legitimate
+     * client-bound destinations.
+     * This means we won't get hidden-service requests, directory requests, or
+     * any non-exit connections */
+    if (!privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
+        return;
+    }
+
     /* Get the time as early as possible, but after we're sure we want it */
     struct timeval now;
     tor_gettimeofday(&now);
@@ -6269,10 +6281,11 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
     const or_circuit_t* orcirc = privcount_get_const_or_circuit(exitconn,
                                                                 NULL);
 
-    /* only collect stream info from exits to legitimate client-bound destinations.
-     * this means we won't get hidden-service requests, directory requests, or
+    /* Only send stream events for connections from exits to legitimate
+     * client-bound destinations.
+     * This means we won't get hidden-service requests, directory requests, or
      * any non-exit connections */
-    if (privcount_data_is_used_for_byte_counters(exitconn, orcirc)) {
+    if (!privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
       return;
     }
 
@@ -6292,7 +6305,8 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
             0, 0);
 }
 
-/* Send a PrivCount circuit end event triggered on orcirc.
+/* Send a PrivCount circuit end event triggered on orcirc, which may be an
+ * entry, exit, or middle connection.
  * Sets the privcount_event_emitted flag in orcirc to ensure that each
  * circuit only emits one event.
  * orcirc must not be NULL. */
@@ -6311,8 +6325,8 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
 
     orcirc->privcount_event_emitted = 1;
 
-    /* Filter out circuit overhead (directory circuits at directories) */
-    if (privcount_data_is_used_for_cell_counters(NULL, TO_CIRCUIT(orcirc))) {
+    /* Filter out circuit overhead (directory circuits at directories). */
+    if (!privcount_data_is_used_for_circuit_events(TO_CIRCUIT(orcirc))) {
       return;
     }
 
@@ -6360,10 +6374,11 @@ control_event_privcount_connection_ended(const or_connection_t *orconn)
         return;
     }
 
-    /* Filter out connection overhead (directory connections at directories) */
-    if (privcount_data_is_used_for_cell_counters(TO_CONN(orconn), NULL)) {
-      return;
+    /* Filter out connection overhead (directory circuits at directories). */
+    if (!privcount_data_is_used_for_connection_events(TO_CONN(orconn))) {
+        return;
     }
+
 
     /* Get the time as early as possible, but after we're sure we want it */
     struct timeval now;

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6145,23 +6145,15 @@ privcount_is_client(const channel_t* chan)
 }
 
 /* Perform a 64-bit saturating add of a and b */
-static uint64_t
+uint64_t
 privcount_add_saturating(uint64_t a, uint64_t b) {
+  /* Check before performing the addition to avoid overflow, even though it
+   * is defined as wrapping on unsigned integers. */
   if (PREDICT_LIKELY(UINT64_MAX - a > b)) {
     return a + b;
   } else {
     return UINT64_MAX;
   }
-}
-
-/* Perform a += b without overflow, and without returning a value
- * total must not be NULL */
-void
-privcount_sum(uint64_t *total, uint64_t increment) {
-  if (BUG(!total)) {
-    return;
-  }
-  *total = privcount_add_saturating(*total, increment);
 }
 
 #define NO_CHANNEL_ADDRESS "0.0.0.0"

--- a/src/or/control.h
+++ b/src/or/control.h
@@ -150,11 +150,11 @@ void control_event_hs_descriptor_content(const char *onion_address,
 
 or_circuit_t* privcount_get_or_circuit(edge_connection_t* exitconn,
                                        or_circuit_t *orcirc);
-int privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
+int privcount_data_is_used_for_byte_counters(const edge_connection_t* exitconn,
                                    const or_circuit_t *orcirc);
-int privcount_is_counted_for_cells(const connection_t *conn,
+int privcount_data_is_used_for_cell_counters(const connection_t *conn,
                                    const circuit_t *circ);
-int privcount_is_counted_for_dns(const edge_connection_t* exitconn,
+int privcount_data_is_used_for_dns_counters(const edge_connection_t* exitconn,
                                  const or_circuit_t *orcirc);
 void privcount_sum(uint64_t *total, uint64_t increment);
 

--- a/src/or/control.h
+++ b/src/or/control.h
@@ -148,11 +148,25 @@ void control_event_hs_descriptor_content(const char *onion_address,
                                          const char *hsdir_fp,
                                          const char *content);
 
-void control_event_privcount_dns_resolved(edge_connection_t *exitconn, or_circuit_t *oncirc);
-void control_event_privcount_stream_data_xferred(edge_connection_t *conn, uint64_t amt, int is_outbound);
-void control_event_privcount_stream_ended(edge_connection_t *conn);
+or_circuit_t* privcount_get_or_circuit(edge_connection_t* exitconn,
+                                       or_circuit_t *orcirc);
+int privcount_is_counted_for_bytes(const edge_connection_t* exitconn,
+                                   const or_circuit_t *orcirc);
+int privcount_is_counted_for_cells(const connection_t *conn,
+                                   const circuit_t *circ);
+int privcount_is_counted_for_dns(const edge_connection_t* exitconn,
+                                 const or_circuit_t *orcirc);
+void privcount_sum(uint64_t *total, uint64_t increment);
+
+void control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
+                                          const or_circuit_t *orcirc);
+void control_event_privcount_stream_data_xferred(
+                                            const edge_connection_t *exitconn,
+                                            const or_circuit_t *orcirc,
+                                            uint64_t amt, int is_outbound);
+void control_event_privcount_stream_ended(const edge_connection_t *exitconn);
 void control_event_privcount_circuit_ended(or_circuit_t *orcirc);
-void control_event_privcount_connection_ended(or_connection_t *orconn);
+void control_event_privcount_connection_ended(const or_connection_t *orconn);
 
 void control_free_all(void);
 

--- a/src/or/control.h
+++ b/src/or/control.h
@@ -164,7 +164,7 @@ int privcount_data_is_used_for_connection_events(const connection_t *conn);
 int privcount_data_is_used_for_dns_events(const edge_connection_t* exitconn,
                                           const or_circuit_t *orcirc);
 
-void privcount_sum(uint64_t *total, uint64_t increment);
+uint64_t privcount_add_saturating(uint64_t a, uint64_t b);
 
 void control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
                                           const or_circuit_t *orcirc);

--- a/src/or/control.h
+++ b/src/or/control.h
@@ -150,12 +150,20 @@ void control_event_hs_descriptor_content(const char *onion_address,
 
 or_circuit_t* privcount_get_or_circuit(edge_connection_t* exitconn,
                                        or_circuit_t *orcirc);
+
+int privcount_data_is_used_for_stream_events(const edge_connection_t* exitconn,
+                                             const or_circuit_t *orcirc);
 int privcount_data_is_used_for_byte_counters(const edge_connection_t* exitconn,
-                                   const or_circuit_t *orcirc);
-int privcount_data_is_used_for_cell_counters(const connection_t *conn,
-                                   const circuit_t *circ);
-int privcount_data_is_used_for_dns_counters(const edge_connection_t* exitconn,
-                                 const or_circuit_t *orcirc);
+                                             const or_circuit_t *orcirc);
+
+int privcount_data_is_used_for_circuit_events(const circuit_t *circ);
+int privcount_data_is_used_for_cell_counters(const circuit_t *circ);
+
+int privcount_data_is_used_for_connection_events(const connection_t *conn);
+
+int privcount_data_is_used_for_dns_events(const edge_connection_t* exitconn,
+                                          const or_circuit_t *orcirc);
+
 void privcount_sum(uint64_t *total, uint64_t increment);
 
 void control_event_privcount_dns_resolved(const edge_connection_t *exitconn,

--- a/src/or/or.h
+++ b/src/or/or.h
@@ -3328,7 +3328,8 @@ typedef struct or_circuit_t {
    */
   uint32_t max_middle_cells;
 
-  /* Excludes cells and bytes that privcount considers overhead */
+  /* Excludes cells and bytes that privcount considers overhead.
+   * Use privcount_sum() when modifying these values to avoid overflow. */
   uint64_t privcount_n_cells_in;
   uint64_t privcount_n_cells_out;
   uint64_t privcount_n_read;

--- a/src/or/or.h
+++ b/src/or/or.h
@@ -3329,7 +3329,8 @@ typedef struct or_circuit_t {
   uint32_t max_middle_cells;
 
   /* Excludes cells and bytes that privcount considers overhead.
-   * Use privcount_sum() when modifying these values to avoid overflow. */
+   * Use privcount_add_saturating() when modifying these values to avoid
+   * overflow. */
   uint64_t privcount_n_cells_in;
   uint64_t privcount_n_cells_out;
   uint64_t privcount_n_read;

--- a/src/or/or.h
+++ b/src/or/or.h
@@ -1568,10 +1568,12 @@ typedef struct edge_connection_t {
 
   /** Bytes read since last call to control_event_stream_bandwidth_used() */
   uint32_t n_read;
+  /* Excludes bytes that privcount considers overhead */
   uint64_t privcount_n_read;
 
   /** Bytes written since last call to control_event_stream_bandwidth_used() */
   uint32_t n_written;
+  /* Excludes bytes that privcount considers overhead */
   uint64_t privcount_n_written;
 
   /** True iff this connection is for a DNS request only. */
@@ -3326,12 +3328,12 @@ typedef struct or_circuit_t {
    */
   uint32_t max_middle_cells;
 
+  /* Excludes cells and bytes that privcount considers overhead */
   uint64_t privcount_n_cells_in;
   uint64_t privcount_n_cells_out;
-  uint64_t privcount_n_read_dns;
-  uint64_t privcount_n_written_dns;
-  uint64_t privcount_n_read_exit;
-  uint64_t privcount_n_written_exit;
+  uint64_t privcount_n_read;
+  uint64_t privcount_n_written;
+  /* Has the circuit ended event been emitted? */
   int privcount_event_emitted;
 
 } or_circuit_t;

--- a/src/or/relay.c
+++ b/src/or/relay.c
@@ -2638,9 +2638,9 @@ channel_flush_from_first_active_circuit, (channel_t *chan, int max))
        * sets it before using it, too. */
       or_circ = TO_OR_CIRCUIT(circ);
       if (chan == or_circ->p_chan) {
-        or_circ->privcount_n_cells_in++;
+        privcount_sum(&or_circ->privcount_n_cells_in, 1);
       } else if (chan == circ->n_chan) {
-        or_circ->privcount_n_cells_out++;
+        privcount_sum(&or_circ->privcount_n_cells_out, 1);
       }
     }
 

--- a/src/or/relay.c
+++ b/src/or/relay.c
@@ -2631,7 +2631,7 @@ channel_flush_from_first_active_circuit, (channel_t *chan, int max))
      */
     cell = cell_queue_pop(queue);
 
-    if (privcount_data_is_used_for_cell_counters(NULL, circ)) {
+    if (privcount_data_is_used_for_cell_counters(circ)) {
       /* We can't use or_circ as-is, because it's only set when
        * chan == or_circ->p_chan
        * But it's safe to overwrite it here, because the cell statistics code

--- a/src/or/relay.c
+++ b/src/or/relay.c
@@ -2631,7 +2631,7 @@ channel_flush_from_first_active_circuit, (channel_t *chan, int max))
      */
     cell = cell_queue_pop(queue);
 
-    if (privcount_is_counted_for_cells(NULL, circ)) {
+    if (privcount_data_is_used_for_cell_counters(NULL, circ)) {
       /* We can't use or_circ as-is, because it's only set when
        * chan == or_circ->p_chan
        * But it's safe to overwrite it here, because the cell statistics code

--- a/src/or/relay.c
+++ b/src/or/relay.c
@@ -2638,9 +2638,13 @@ channel_flush_from_first_active_circuit, (channel_t *chan, int max))
        * sets it before using it, too. */
       or_circ = TO_OR_CIRCUIT(circ);
       if (chan == or_circ->p_chan) {
-        privcount_sum(&or_circ->privcount_n_cells_in, 1);
+        or_circ->privcount_n_cells_in = privcount_add_saturating(
+                                                or_circ->privcount_n_cells_in,
+                                                1);
       } else if (chan == circ->n_chan) {
-        privcount_sum(&or_circ->privcount_n_cells_out, 1);
+        or_circ->privcount_n_cells_out = privcount_add_saturating(
+                                                or_circ->privcount_n_cells_out,
+                                                1);
       }
     }
 

--- a/src/or/relay.c
+++ b/src/or/relay.c
@@ -2631,9 +2631,13 @@ channel_flush_from_first_active_circuit, (channel_t *chan, int max))
      */
     cell = cell_queue_pop(queue);
 
-    if(get_options()->EnablePrivCount && !CIRCUIT_IS_ORIGIN(circ)) {
+    if (privcount_is_counted_for_cells(NULL, circ)) {
+      /* We can't use or_circ as-is, because it's only set when
+       * chan == or_circ->p_chan
+       * But it's safe to overwrite it here, because the cell statistics code
+       * sets it before using it, too. */
       or_circ = TO_OR_CIRCUIT(circ);
-      if(chan == or_circ->p_chan) {
+      if (chan == or_circ->p_chan) {
         or_circ->privcount_n_cells_in++;
       } else if (chan == circ->n_chan) {
         or_circ->privcount_n_cells_out++;


### PR DESCRIPTION
Consistently count bytes, cells, streams, circuits, and connections.
Consistently exclude directory (including BEGINDIR), origin, and (for streams) non-exit circuits.

Stubs out unused fields: they will be removed in #244.