### PR TITLE
Modify Control Port event fields

### DIFF
--- a/src/or/connection.c
+++ b/src/or/connection.c
@@ -3632,7 +3632,7 @@ connection_read_to_buf(connection_t *conn, ssize_t *max_to_read,
                                                   n_read);
       }
       if (privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
-        control_event_privcount_stream_data_xferred(exitconn, orcirc,
+        control_event_privcount_stream_bytes_transferred(exitconn, orcirc,
                                                     n_read, 0);
       }
     }
@@ -3943,7 +3943,7 @@ connection_handle_write_impl(connection_t *conn, int force)
                                                 n_written);
     }
     if (privcount_data_is_used_for_stream_events(exitconn, orcirc)) {
-      control_event_privcount_stream_data_xferred(exitconn, orcirc,
+      control_event_privcount_stream_bytes_transferred(exitconn, orcirc,
                                                   n_written, 1);
     }
   }

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6285,16 +6285,15 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
     struct timeval now;
     tor_gettimeofday(&now);
 
-    /* ChanID, CircID, StreamID, ExitPort, ReadBW, WriteBW, TimeStart, TimeEnd, isDNS, isDir */
+    /* ChanID, CircID, StreamID, ExitPort, ReadBW, WriteBW, TimeStart, TimeEnd */
     send_control_event(EVENT_PRIVCOUNT_STREAM_ENDED,
-            "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld %d %d\r\n",
+            "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld\r\n",
             orcirc && orcirc->p_chan ? orcirc->p_chan->global_identifier : 0,
             orcirc ? orcirc->p_circ_id : 0,
             exitconn->stream_id, exitconn->base_.port,
             exitconn->privcount_n_read, exitconn->privcount_n_written,
             (long)exitconn->base_.timestamp_created_tv.tv_sec, (long)exitconn->base_.timestamp_created_tv.tv_usec,
-            (long)now.tv_sec, (long)now.tv_usec,
-            0, 0);
+            (long)now.tv_sec, (long)now.tv_usec);
 }
 
 /* Send a PrivCount circuit end event triggered on orcirc, which may be an

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6272,6 +6272,30 @@ privcount_chan_addr_to_str_dup(const channel_t *chan)
   }
 }
 
+/* Return a newly allocated string containing a formatted verion of tv.
+ * tv must not be NULL.
+ * The returned string must be freed using tor_free(). */
+static char *
+privcount_timeval_to_str_dup(const struct timeval *tv)
+{
+  tor_assert(tv);
+
+  char *str = NULL;
+  tor_asprintf(&str, "%ld.%06ld", (long)tv->tv_sec, (long)tv->tv_usec);
+  return str;
+}
+
+/* Return a newly allocated string containing a formatted verion of
+ * the current time.
+ * The returned string must be freed using tor_free(). */
+static char *
+privcount_timeval_now_to_str_dup(void)
+{
+  struct timeval now;
+  tor_gettimeofday(&now);
+  return privcount_timeval_to_str_dup(&now);
+}
+
 /* Send a PrivCount DNS resolution event triggered on exitconn and orcirc.
  * This event includes failed resolves, but excludes immediate results, such
  * as trivial IP address resolves and failed malformed resolves.
@@ -6333,18 +6357,19 @@ control_event_privcount_stream_bytes_transferred(const edge_connection_t *exitco
     }
 
     /* Get the time as early as possible, but after we're sure we want it */
-    struct timeval now;
-    tor_gettimeofday(&now);
+    char *now_str = privcount_timeval_now_to_str_dup();
 
     /* ChanID, CircID, StreamID, Direction, BW, Time */
     send_control_event(EVENT_PRIVCOUNT_STREAM_BYTES_TRANSFERRED,
-            "650 PRIVCOUNT_STREAM_BYTES_TRANSFERRED %"PRIu64" %"PRIu32" %"PRIu16" %d %"PRIu64" %ld.%06ld\r\n",
+            "650 PRIVCOUNT_STREAM_BYTES_TRANSFERRED %"PRIu64" %"PRIu32" %"PRIu16" %d %"PRIu64" %s\r\n",
             orcirc && orcirc->p_chan ? orcirc->p_chan->global_identifier : 0,
             orcirc ? orcirc->p_circ_id : 0,
             exitconn->stream_id,
             is_outbound,
             amt,
-            (long)now.tv_sec, (long)now.tv_usec);
+            now_str);
+
+    tor_free(now_str);
 }
 
 /* Send a PrivCount stream end event triggered on exitconn.
@@ -6372,18 +6397,22 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
     }
 
     /* Get the time as early as possible, but after we're sure we want it */
-    struct timeval now;
-    tor_gettimeofday(&now);
+    char *now_str = privcount_timeval_now_to_str_dup();
+    char *created_str = privcount_timeval_to_str_dup(
+                                      &exitconn->base_.timestamp_created_tv);
 
     /* ChanID, CircID, StreamID, ExitPort, ReadBW, WriteBW, TimeStart, TimeEnd */
     send_control_event(EVENT_PRIVCOUNT_STREAM_ENDED,
-            "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld\r\n",
+            "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %s %s\r\n",
             orcirc && orcirc->p_chan ? orcirc->p_chan->global_identifier : 0,
             orcirc ? orcirc->p_circ_id : 0,
             exitconn->stream_id, exitconn->base_.port,
             exitconn->privcount_n_read, exitconn->privcount_n_written,
-            (long)exitconn->base_.timestamp_created_tv.tv_sec, (long)exitconn->base_.timestamp_created_tv.tv_usec,
-            (long)now.tv_sec, (long)now.tv_usec);
+            created_str,
+            now_str);
+
+    tor_free(now_str);
+    tor_free(created_str);
 }
 
 /* Send a PrivCount circuit end event triggered on orcirc, which may be an
@@ -6412,8 +6441,11 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
     }
 
     /* Get the time as early as possible, but after we're sure we want it */
-    struct timeval now;
-    tor_gettimeofday(&now);
+    char *now_str = privcount_timeval_now_to_str_dup();
+    /* the difference between timestamp_created and timestamp_began only
+     * matters on clients */
+    char *created_str = privcount_timeval_to_str_dup(
+                                      &orcirc->base_.timestamp_created);
 
     /* we already know this is not an origin circ since we have a or_circuit_t struct */
     tor_assert_nonfatal(orcirc->p_chan);
@@ -6425,17 +6457,19 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
 
     /* ChanID, CircID, NCellsIn, NCellsOut, ReadBWExit, WriteBWExit, TimeStart, TimeEnd, PrevIP, PrevIsClient, NextIP, NextIsEdge */
     send_control_event(EVENT_PRIVCOUNT_CIRCUIT_ENDED,
-            "650 PRIVCOUNT_CIRCUIT_ENDED %"PRIu64" %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld %s %d %s %d\r\n",
+            "650 PRIVCOUNT_CIRCUIT_ENDED %"PRIu64" %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %s %s %s %d %s %d\r\n",
             orcirc->p_chan ? orcirc->p_chan->global_identifier : 0, orcirc->p_circ_id,
             orcirc->privcount_n_cells_in, orcirc->privcount_n_cells_out,
             orcirc->privcount_n_read, orcirc->privcount_n_written,
-            (long)orcirc->base_.timestamp_created.tv_sec, (long)orcirc->base_.timestamp_created.tv_usec,
-            (long)now.tv_sec, (long)now.tv_usec,
+            created_str,
+            now_str,
             p_addr,
             prev_is_client,
             n_addr,
             next_is_edge);
 
+    tor_free(now_str);
+    tor_free(created_str);
     tor_free(p_addr);
     tor_free(n_addr);
 }
@@ -6460,8 +6494,9 @@ control_event_privcount_connection_ended(const or_connection_t *orconn)
 
 
     /* Get the time as early as possible, but after we're sure we want it */
-    struct timeval now;
-    tor_gettimeofday(&now);
+    char *now_str = privcount_timeval_now_to_str_dup();
+    char *created_str = privcount_timeval_to_str_dup(
+                                      &orconn->base_.timestamp_created_tv);
 
     const channel_t *chan = TLS_CHAN_TO_BASE(orconn->chan);
     int is_client = privcount_is_client(chan);
@@ -6470,13 +6505,15 @@ control_event_privcount_connection_ended(const or_connection_t *orconn)
 
     /* ChanID, TimeStart, TimeEnd, IP, isClient */
     send_control_event(EVENT_PRIVCOUNT_CONNECTION_ENDED,
-            "650 PRIVCOUNT_CONNECTION_ENDED %"PRIu64" %ld.%06ld %ld.%06ld %s %d\r\n",
+            "650 PRIVCOUNT_CONNECTION_ENDED %"PRIu64" %s %s %s %d\r\n",
             chan ? chan->global_identifier : 0,
-            (long)orconn->base_.timestamp_created_tv.tv_sec, (long)orconn->base_.timestamp_created_tv.tv_usec,
-            (long)now.tv_sec, (long)now.tv_usec,
+            created_str,
+            now_str,
             addr,
             is_client);
 
+    tor_free(now_str);
+    tor_free(created_str);
     tor_free(addr);
 }
 

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6468,14 +6468,14 @@ control_event_privcount_connection_ended(const or_connection_t *orconn)
 
     char *addr = privcount_chan_addr_to_str_dup(chan);
 
-    /* ChanID, TimeStart, TimeEnd, IP, isClient, isRelay */
+    /* ChanID, TimeStart, TimeEnd, IP, isClient */
     send_control_event(EVENT_PRIVCOUNT_CONNECTION_ENDED,
-            "650 PRIVCOUNT_CONNECTION_ENDED %"PRIu64" %ld.%06ld %ld.%06ld %s %d %d\r\n",
+            "650 PRIVCOUNT_CONNECTION_ENDED %"PRIu64" %ld.%06ld %ld.%06ld %s %d\r\n",
             chan ? chan->global_identifier : 0,
             (long)orconn->base_.timestamp_created_tv.tv_sec, (long)orconn->base_.timestamp_created_tv.tv_usec,
             (long)now.tv_sec, (long)now.tv_usec,
             addr,
-            is_client, !is_client);
+            is_client);
 
     tor_free(addr);
 }

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6423,19 +6423,18 @@ control_event_privcount_circuit_ended(or_circuit_t *orcirc)
     char *p_addr = privcount_chan_addr_to_str_dup(orcirc->p_chan);
     char *n_addr = privcount_chan_addr_to_str_dup(orcirc->base_.n_chan);
 
-    /* ChanID, CircID, nCellsIn, nCellsOut, ReadBWDNS, WriteBWDNS, ReadBWExit, WriteBWExit, TimeStart, TimeEnd, PrevIP, prevIsClient, prevIsRelay, NextIP, NextIsEdge, nextIsRelay */
+    /* ChanID, CircID, NCellsIn, NCellsOut, ReadBWExit, WriteBWExit, TimeStart, TimeEnd, PrevIP, PrevIsClient, NextIP, NextIsEdge */
     send_control_event(EVENT_PRIVCOUNT_CIRCUIT_ENDED,
-            "650 PRIVCOUNT_CIRCUIT_ENDED %"PRIu64" %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld %s %d %d %s %d %d\r\n",
+            "650 PRIVCOUNT_CIRCUIT_ENDED %"PRIu64" %"PRIu32" %"PRIu64" %"PRIu64" %"PRIu64" %"PRIu64" %ld.%06ld %ld.%06ld %s %d %s %d\r\n",
             orcirc->p_chan ? orcirc->p_chan->global_identifier : 0, orcirc->p_circ_id,
             orcirc->privcount_n_cells_in, orcirc->privcount_n_cells_out,
-            (uint64_t)0, (uint64_t)0,
             orcirc->privcount_n_read, orcirc->privcount_n_written,
             (long)orcirc->base_.timestamp_created.tv_sec, (long)orcirc->base_.timestamp_created.tv_usec,
             (long)now.tv_sec, (long)now.tv_usec,
             p_addr,
-            prev_is_client, !prev_is_client,
+            prev_is_client,
             n_addr,
-            next_is_edge, !next_is_edge);
+            next_is_edge);
 
     tor_free(p_addr);
     tor_free(n_addr);

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6310,23 +6310,27 @@ control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
       return;
     }
 
+    if (!exitconn || !orcirc) {
+      return;
+    }
+
     /* Filter out directory data (at the directory) and non-exit connections */
     if (privcount_data_is_used_for_dns_events(exitconn, orcirc)) {
         return;
     }
 
-    /* There's no time here. We should fix that if we ever use this event */
-#if 0
     /* Get the time as early as possible, but after we're sure we want it */
-    struct timeval now;
-    tor_gettimeofday(&now);
-#endif
+    char *now_str = privcount_timeval_now_to_str_dup();
 
+    /* ChanID, CircID, StreamID, Address, Time */
     send_control_event(EVENT_PRIVCOUNT_DNS_RESOLVED,
-                       "650 PRIVCOUNT_DNS_RESOLVED %" PRIu64 " %" PRIu32 " %s\r\n",
+                       "650 PRIVCOUNT_DNS_RESOLVED %" PRIu64 " %" PRIu32 " %" PRIu16 " %s %s\r\n",
                        orcirc->p_chan->global_identifier,
                        orcirc->p_circ_id,
-                       exitconn->base_.address);
+                       exitconn->stream_id,
+                       exitconn->base_.address,
+                       now_str);
+    tor_free(now_str);
 }
 
 /* Send a PrivCount stream data transfer event triggered on exitconn and

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6222,7 +6222,7 @@ control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
  * exitconn must not be NULL.
  * If orcirc is NULL, it is looked up from exitconn. */
 void
-control_event_privcount_stream_data_xferred(const edge_connection_t *exitconn,
+control_event_privcount_stream_bytes_transferred(const edge_connection_t *exitconn,
                                             const or_circuit_t *orcirc,
                                             uint64_t amt, int is_outbound)
 {

--- a/src/or/control.c
+++ b/src/or/control.c
@@ -6248,6 +6248,7 @@ privcount_add_saturating(uint64_t a, uint64_t b) {
 
 #define NO_CHANNEL_ADDRESS "0.0.0.0"
 #define NO_CONNECTION_ADDRESS "0.0.0.0"
+#define NO_CONNECTION_HOST "no-host"
 
 /* Return a newly allocated string containing the remote address of chan,
  * or a placeholder if chan is NULL or has no connection.
@@ -6269,6 +6270,41 @@ privcount_chan_addr_to_str_dup(const channel_t *chan)
     }
   } else {
     return tor_strdup(NO_CHANNEL_ADDRESS);
+  }
+}
+
+/* Return a newly allocated string containing the resolved remote address of
+ * exitconn, or a placeholder if exitconn is NULL or has a null addr.
+ * The returned string must be freed using tor_free(). */
+static char *
+privcount_conn_addr_to_str_dup(const edge_connection_t *exitconn)
+{
+  if (exitconn) {
+    if (!tor_addr_is_null(&exitconn->base_.addr)) {
+      return tor_addr_to_str_dup(&exitconn->base_.addr);
+    } else {
+      return tor_strdup(NO_CONNECTION_ADDRESS);
+    }
+  } else {
+    return tor_strdup(NO_CONNECTION_ADDRESS);
+  }
+}
+
+
+/* Return a newly allocated string containing the remote host name of exitconn,
+ * or a placeholder if exitconn is NULL or has no address.
+ * The returned string must be freed using tor_free(). */
+static char *
+privcount_conn_host_to_str_dup(const edge_connection_t *exitconn)
+{
+  if (exitconn) {
+    if (exitconn->base_.address) {
+      return tor_strdup(exitconn->base_.address);
+    } else {
+      return privcount_conn_addr_to_str_dup(exitconn);
+    }
+  } else {
+    return tor_strdup(NO_CONNECTION_HOST);
   }
 }
 
@@ -6405,15 +6441,20 @@ control_event_privcount_stream_ended(const edge_connection_t *exitconn)
     char *created_str = privcount_timeval_to_str_dup(
                                       &exitconn->base_.timestamp_created_tv);
 
-    /* ChanID, CircID, StreamID, ExitPort, ReadBW, WriteBW, TimeStart, TimeEnd */
+    char *host_str = privcount_conn_host_to_str_dup(exitconn);
+    char *addr_str = privcount_conn_addr_to_str_dup(exitconn);
+
+    /* ChanID, CircID, StreamID, ExitPort, ReadBW, WriteBW, TimeStart, TimeEnd, RemoteHost, RemoteIP */
     send_control_event(EVENT_PRIVCOUNT_STREAM_ENDED,
-            "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %s %s\r\n",
+            "650 PRIVCOUNT_STREAM_ENDED %"PRIu64" %"PRIu32" %"PRIu16" %"PRIu16" %"PRIu64" %"PRIu64" %s %s %s %s\r\n",
             orcirc && orcirc->p_chan ? orcirc->p_chan->global_identifier : 0,
             orcirc ? orcirc->p_circ_id : 0,
             exitconn->stream_id, exitconn->base_.port,
             exitconn->privcount_n_read, exitconn->privcount_n_written,
             created_str,
-            now_str);
+            now_str,
+            host_str,
+            addr_str);
 
     tor_free(now_str);
     tor_free(created_str);

--- a/src/or/control.h
+++ b/src/or/control.h
@@ -168,7 +168,7 @@ uint64_t privcount_add_saturating(uint64_t a, uint64_t b);
 
 void control_event_privcount_dns_resolved(const edge_connection_t *exitconn,
                                           const or_circuit_t *orcirc);
-void control_event_privcount_stream_data_xferred(
+void control_event_privcount_stream_bytes_transferred(
                                             const edge_connection_t *exitconn,
                                             const or_circuit_t *orcirc,
                                             uint64_t amt, int is_outbound);


### PR DESCRIPTION
Remove unused fields from PrivCount events.
Add new fields to PrivCount events.
Fix a major bug in exit connection filtering.

Refactor to remove duplicate code.

(This is the last functional change in PrivCount 0.2.0.)